### PR TITLE
Add option to disable NAT iptables rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ These options can be configured in `docker-compose.yml` under `environment`.
 | `WG_DEFAULT_ADDRESS` | `10.8.0.x` | `10.6.0.x` | Clients IP address range |
 | `WG_DEFAULT_DNS` | `1.1.1.1` | `8.8.8.8, 8.8.4.4` | DNS server clients will use |
 | `WG_ALLOWED_IPS` | `0.0.0.0/0, ::/0` | `192.168.15.0/24, 10.0.1.0/24` | Allowed IPs clients will use |
+| `WG_NAT` | `true` | `false` | Enable or disable NAT iptables rules
 
 > If you change `WG_PORT`, make sure to also change the exposed port.
 

--- a/src/config.js
+++ b/src/config.js
@@ -13,3 +13,4 @@ module.exports.WG_DEFAULT_DNS = typeof process.env.WG_DEFAULT_DNS === 'string'
   ? process.env.WG_DEFAULT_DNS
   : '1.1.1.1';
 module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
+module.exports.WG_NAT = process.env.WG_NAT || true;


### PR DESCRIPTION
I would like to use wg-easy with `--network=host` to easily manage the interface and add custom iptables rules. This requires some changes, one of the most important is this one.

This PR disables the iptables rules. I've called it `NAT rules` because in my testing the other 3 rules for INPUT and FORWARD aren't useful because the default policy is already ACCEPT. If you want, I can remove the excess lines, change the naming of the option or leave it as is.

Let me know if you want me to combine everything in a single pull request. These are the patches I would like to submit:
- [ ] Add a hostname option to specify the listening address for the UI instead of `0.0.0.0`
- [x] Add a keep-alive option
- [ ] Add a WG_LISTEN_PORT option to change the port the interface listens on.
- [ ] Add a wg-interface option to be able to change the wireguard interface (e.g `wg0` -> `wg1`)
- [x] Be able to disable DNS (just fixed :slightly_smiling_face: )