### PR TITLE
Add dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Adding Dependabot should help catch issues and update dependencies as needed.  You may need to make some tweaks in the repo settings, I'm not sure.

Note that when I forked this and added it to my repo, it made three PRs:

https://github.com/FuzzyMistborn/wg-easy/pull/1
https://github.com/FuzzyMistborn/wg-easy/pull/3
https://github.com/FuzzyMistborn/wg-easy/pull/4

The first seems like an important one to fix regardless of whether you want to add Dependabot.