### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ If you haven't installed Docker yet, install it by running:
 ```bash
 $ curl -sSL https://get.docker.com | sh
 $ sudo usermod -aG docker $(whoami)
-$ bash
 ```
+Logout and login for the change to take effect.
 
 You might need to install docker-compose separately. For example, on a Raspberry Pi:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ If you haven't installed Docker yet, install it by running:
 
 ```bash
 $ curl -sSL https://get.docker.com | sh
-$ sudo sh get-docker.sh
 $ sudo usermod -aG docker $(whoami)
 $ bash
 ```


### PR DESCRIPTION
`sudo sh get-docker.sh` is not needed, since `curl -sSL https://get.docker.com | sh` do the install too