### PR TITLE
Add dumb-init to avoid zombie processes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-alpine
 
 # Install Linux packages
-RUN apk add -U wireguard-tools
+RUN apk add -U --no-cache wireguard-tools dumb-init
 
 # Copy Web UI
 COPY src/ /app/
@@ -16,4 +16,4 @@ EXPOSE 51821/tcp
 ENV DEBUG=Server,WireGuard
 
 # Run Web UI
-CMD ["node", "server.js"]
+CMD ["/usr/bin/dumb-init", "node", "server.js"]


### PR DESCRIPTION
### Changes:
* Added `--no-cache` to avoid caching apk downloads
* Added `dumb-init` package to avoid zombie processes since node is not suppose to run as PID 1.

More information here: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/

### Closes #65 

### Test:

![image](https://user-images.githubusercontent.com/835733/133535317-95bd0b7c-4f02-4fbd-b4ef-45a39eb37909.png)

