### PR TITLE
Normalize config file name for download to make it work on Windows

### DIFF
--- a/src/lib/Server.js
+++ b/src/lib/Server.js
@@ -99,7 +99,8 @@ module.exports = class Server {
         const { clientId } = req.params;
         const client = await WireGuard.getClient({ clientId });
         const config = await WireGuard.getClientConfiguration({ clientId });
-        res.header('Content-Disposition', `attachment; filename="${client.name}.conf"`);
+        const configName = client.name.replace(/[^a-zA-Z0-9_=+.-]/g, '-').replace(/(-{2,}|-$)/g, '-').replace(/-$/, '').substring(0, 32);
+        res.header('Content-Disposition', `attachment; filename="${configName}.conf"`);
         res.header('Content-Type', 'text/plain');
         res.send(config);
       }))


### PR DESCRIPTION
Client name is derived from config file name when importing configuration to WireGuard on Windows and it only accepts names satisfying `/^[a-zA-Z0-9_=+.-]{1,32}$/`. For more information look at https://github.com/WireGuard/wireguard-windows/blob/af60ab229954519b8295bb3ef453231f4d3b9087/conf/name.go#L24.

This PR implements a name normalization where invalid characters are replaced by `-`.

Without this PR WireGuard on Windows throws `Tunnel name ‘%s’ is invalid.` error when importing config file with invalid characters in its file name.