### PR TITLE
Allow custom rules using `FIREWALL_RULES`

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,4 +13,13 @@ module.exports.WG_DEFAULT_ADDRESS = process.env.WG_DEFAULT_ADDRESS || '10.8.0.x'
 module.exports.WG_DEFAULT_DNS = typeof process.env.WG_DEFAULT_DNS === 'string'
   ? process.env.WG_DEFAULT_DNS
   : '1.1.1.1';
+module.exports.FIREWALL_RULES = process.env.FIREWALL_RULES === 'false'
+  ? false
+  : process.env.FIREWALL_RULES?.split(';') || [
+    `iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE`,
+    'iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT',
+    'iptables -A FORWARD -i wg0 -j ACCEPT',
+    'iptables -A FORWARD -o wg0 -j ACCEPT',
+  ];
+
 module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -18,6 +18,7 @@ const {
   WG_DEFAULT_ADDRESS,
   WG_PERSISTENT_KEEPALIVE,
   WG_ALLOWED_IPS,
+  FIREWALL_RULES
 } = require('../config');
 
 module.exports = class WireGuard {
@@ -54,10 +55,11 @@ module.exports = class WireGuard {
         await this.__saveConfig(config);
         await Util.exec('wg-quick down wg0').catch(() => {});
         await Util.exec('wg-quick up wg0');
-        await Util.exec(`iptables -t nat -A POSTROUTING -s ${WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE`);
-        await Util.exec('iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT');
-        await Util.exec('iptables -A FORWARD -i wg0 -j ACCEPT');
-        await Util.exec('iptables -A FORWARD -o wg0 -j ACCEPT');
+
+        if (FIREWALL_RULES) {
+          await Promise.all(FIREWALL_RULES.map(rule => Util.exec(rule.trim())));
+        }
+
         await this.__syncConfig();
 
         return config;


### PR DESCRIPTION
Relates to https://github.com/WeeJeWel/wg-easy/pull/43, allows the user to pass through `FIREWALL_RULES` environment variable, which can be set to `false` to disable completely.

Note that I'm not really sure that passing through as an environment var is the best method, but just wanted to get a POC that works up to explains what I mean.

Did some testing and all works well, but note: 
- This does no checks on if the 'rules' are actually valid, it just passes through each line to the Util.exec command as-is, meaning anything can be run.
- If a command is invalid, the container will break on startup (which is probably not a terrible thing anyway).

For my use case specifically, I needed my connection to MASQUERADE through tun0 rather than eth0, therefore:

`FIREWALL_RULES=iptables -t nat -A POSTROUTING -s 10.11.11.0/24 -o tun0 -j MASQUERADE;iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT; iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACCEPT`

Works for me

