### PR TITLE
Removed sensitive info (private keys) from being logged

### DIFF
--- a/src/lib/Util.js
+++ b/src/lib/Util.js
@@ -52,9 +52,15 @@ module.exports = class Util {
     };
   }
 
-  static async exec(cmd) {
+  static async exec(cmd, hide=null) {
     // eslint-disable-next-line no-console
-    console.log(`$ ${cmd}`);
+
+    if (hide == null) {
+      console.log(`$ ${cmd}`);
+    } else {
+      // Don't log sensitive information
+      console.log(`$ ${cmd.replace(hide, "*HIDDEN*")}`);
+    }
 
     if (process.platform !== 'linux') {
       return '';

--- a/src/lib/Util.js
+++ b/src/lib/Util.js
@@ -52,14 +52,14 @@ module.exports = class Util {
     };
   }
 
-  static async exec(cmd, hide=null) {
-    // eslint-disable-next-line no-console
-
+  static async exec(cmd, hide = null) {
     if (hide == null) {
+      // eslint-disable-next-line no-console
       console.log(`$ ${cmd}`);
     } else {
       // Don't log sensitive information
-      console.log(`$ ${cmd.replace(hide, "*HIDDEN*")}`);
+      // eslint-disable-next-line no-console
+      console.log(`$ ${cmd.replace(hide, '*HIDDEN*')}`);
     }
 
     if (process.platform !== 'linux') {

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -37,7 +37,7 @@ module.exports = class WireGuard {
           debug('Configuration loaded.');
         } catch (err) {
           const privateKey = await Util.exec('wg genkey');
-          const publicKey = await Util.exec(`echo ${privateKey} | wg pubkey`);
+          const publicKey = await Util.exec(`echo ${privateKey} | wg pubkey`, privateKey);
           const address = WG_DEFAULT_ADDRESS.replace('x', '1');
 
           config = {
@@ -202,7 +202,7 @@ Endpoint = ${WG_HOST}:${WG_PORT}`;
     const config = await this.getConfig();
 
     const privateKey = await Util.exec('wg genkey');
-    const publicKey = await Util.exec(`echo ${privateKey} | wg pubkey`);
+    const publicKey = await Util.exec(`echo ${privateKey} | wg pubkey`, privateKey);
     const preSharedKey = await Util.exec('wg genpsk');
 
     // Calculate next IP


### PR DESCRIPTION
Private keys should not be visible in logs.

Example of new output:
```
$ wg genkey
$ echo *HIDDEN* | wg pubkey
$ wg genpsk
```