### PR TITLE
Use relative paths for client

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -185,7 +185,7 @@
 
                   <!-- Show QR-->
                   <button class="align-middle bg-gray-100 hover:bg-red-800 hover:text-white p-2 rounded transition"
-                    title="Show QR Code" @click="qrcode = `/api/wireguard/client/${client.id}/qrcode.svg`">
+                    title="Show QR Code" @click="qrcode = `api/wireguard/client/${client.id}/qrcode.svg`">
                     <svg class="w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                       stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -194,7 +194,7 @@
                   </button>
 
                   <!-- Download Config -->
-                  <a :href="'/api/wireguard/client/' + client.id + '/configuration'" download
+                  <a :href="'api/wireguard/client/' + client.id + '/configuration'" download
                     class="align-middle inline-block bg-gray-100 hover:bg-red-800 hover:text-white p-2 rounded transition"
                     title="Download Configuration">
                     <svg class="w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
@@ -456,11 +456,11 @@
 
   </div>
 
-  <script src="/js/vendor/vue.min.js"></script>
-  <script src="/js/vendor/md5.min.js"></script>
-  <script src="/js/vendor/timeago.min.js"></script>
-  <script src="/js/api.js"></script>
-  <script src="/js/app.js"></script>
+  <script src="js/vendor/vue.min.js"></script>
+  <script src="js/vendor/md5.min.js"></script>
+  <script src="js/vendor/timeago.min.js"></script>
+  <script src="js/api.js"></script>
+  <script src="js/app.js"></script>
 </body>
 
 </html>

--- a/src/www/js/api.js
+++ b/src/www/js/api.js
@@ -6,7 +6,7 @@
 class API {
 
   async call({ method, path, body }) {
-    const res = await fetch(`/api${path}`, {
+    const res = await fetch(`api${path}`, {
       method,
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
I wanted to deploy this GUI on `https://domain.tld/wg-easy/`, but it was not working properly, since some links were absolute and expecting `/api` and `/js` on root of my domain.

I changed them to relative paths, so tht such deployments are possible. Or would you prefer having it environment vairable e.g. `BASE_PATH=/wg-easy/` ?