### PR TITLE
Add Helm chart and Github workflow to publish to gh-pages branch

### DIFF
--- a/.github/workflows/deploy-helm-chart.yml
+++ b/.github/workflows/deploy-helm-chart.yml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ docker pull weejewel/wg-easy
 ```
 
 And then run the `docker run -d \ ...` command above again.
+
+# Helm Installation
+
+Available Helm values and their defaults can be found in the [chart readme](https://github.com/WeeJeWel/wg-easy/blob/main/charts/wg-easy/README.md)
+
+```bash
+helm repo add wg-easy https://weejewel.github.io/wg-easy
+helm search wg-easy
+```

--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: wg-easy
 description: A Wireguard Easy Helm chart
 type: application
+icon: https://www.wireguard.com/img/wireguard.svg
 # This is the chart version.
 version: 0.1.0
 # This is the version number of the application being deployed.
-appVersion: 4
+appVersion: "4"

--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: wg-easy
+description: A Wireguard Easy Helm chart
+type: application
+# This is the chart version.
+version: 0.1.0
+# This is the version number of the application being deployed.
+appVersion: 4

--- a/charts/wg-easy/README.md
+++ b/charts/wg-easy/README.md
@@ -1,0 +1,34 @@
+
+WireGuard Easy Helm Chart
+===========
+
+A [WireGuard Easy](https://github.com/WeeJeWel/wg-easy) Helm Chart.
+
+
+## Configuration
+
+The following table lists the configurable parameters of the wg-easy chart and their default values.
+
+| Parameter                | Description             | Default        |
+| ------------------------ | ----------------------- | -------------- |
+| `web.password` | When set, requires a password when logging in to the Web UI. | `""` |
+| `web.service.type` | Service Type to create for the wg-easy front-end service. | `"ClusterIP"` |
+| `web.service.port` | The TCP port of the wg-easy front-end for Wireguard. | `51821` |
+| `web.service.externalTrafficPolicy` | Wireguard Service externalTrafficPolicy | `Local` |
+| `web.service.loadBalancerIP` | Wireguard Service externalTrafficPolicy | `null` |
+| `wireguard.service.type` | Service Type to create for the Wireguard VPN service | `"ClusterIP"` |
+| `wireguard.service.port` | The UDP port for the Wireguard VPN service. | `51820` |
+| `wireguard.service.externalTrafficPolicy` | Wireguard Service externalTrafficPolicy | `Local` |
+| `wireguard.host` | The public hostname or IP address of your VPN server. Required. | `""` |
+| `wireguard.clientAddrRange` | Client IP address range. | `"10.8.0.x"` |
+| `wireguard.dns` | DNS server clients will use. | `"1.1.1.1"` |
+| `wireguard.allowedIps` | Allowed IP's clients will use. | `"0.0.0.0/0, ::/0"` |
+| `wireguard.persistentKeepalive` | Value in seconds to keep the "connection" open. | `0` |
+| `ingress.enabled` | Enable Ingress creation if true. | `false` |
+| `ingress.annotations` | Annotations to be applied to the Ingress object when Ingress is enabled. | `{}` |
+| `ingress.hosts` | Hostnames to use with Ingress, when enabled. | `[{"host": "chart-example.local", "paths": []}]` |
+| `persistence.enabled` | When set to true, this will enable persistence. | `false` |
+| `persistence.size` | Volume size when using persistence. | `"100Mi"` |
+| `persistence.annotations` | Persistent Volume Annotations | `{}` |
+| `persistence.accessModes` | Persistent Volume Access Mode | `["ReadWriteOnce"]` |
+| `persistence.subPath` | Persistent Volume sub-path | `""` |

--- a/charts/wg-easy/templates/NOTES.txt
+++ b/charts/wg-easy/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.web.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "wg-easy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.web.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "wg-easy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "wg-easy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.web.service.port }}
+{{- else if contains "ClusterIP" .Values.web.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "wg-easy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/wg-easy/templates/_helpers.tpl
+++ b/charts/wg-easy/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wg-easy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wg-easy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wg-easy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "wg-easy.labels" -}}
+helm.sh/chart: {{ include "wg-easy.chart" . }}
+{{ include "wg-easy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wg-easy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wg-easy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wg-easy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "wg-easy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/wg-easy/templates/deployment.yaml
+++ b/charts/wg-easy/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "wg-easy.fullname" . }}{{- end }}
         {{- end }}
         {{- if not .Values.persistence.enabled }}
-        emptyDir: {}
+          emptyDir: {}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/wg-easy/templates/deployment.yaml
+++ b/charts/wg-easy/templates/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wg-easy.fullname" . }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "wg-easy.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "wg-easy.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "wg-easy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            capabilities:
+              add: ['NET_ADMIN']
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 51821
+              protocol: TCP
+            - name: wireguard
+              containerPort: 51820
+              protocol: UDP
+          env:
+            - name: WG_HOST
+              value: "{{ .Values.wireguard.host }}"
+            {{- if .Values.web.password }}
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.web.password.secretName }}"
+                  key: webpassword
+            {{- end }}
+            {{- if .Values.wireguard.service.port }}
+            - name: WG_PORT
+              value: "{{ .Values.wireguard.service.port }}"
+            {{- end }}
+            {{- if .Values.wireguard.clientAddrRange }}
+            - name: WG_DEFAULT_ADDRESS
+              value: "{{ .Values.wireguard.clientAddrRange }}"
+            {{- end }}
+            {{- if .Values.wireguard.dns }}
+            - name: WG_DEFAULT_DNS
+              value: "{{ .Values.wireguard.dns }}"
+            {{- end }}
+            {{- if .Values.wireguard.allowedIps }}
+            - name: WG_ALLOWED_IPS
+              value: "{{ .Values.wireguard.allowedIps }}"
+            {{- end }}
+            {{- if .Values.wireguard.persistentKeepalive }}
+            - name: WG_PERSISTENT_KEEPALIVE
+              value: "{{ .Values.wireguard.persistentKeepalive }}"
+            {{- end }}
+          volumeMounts:
+            - name: tun
+              mountPath: /dev/net/tun
+            - name: config
+              mountPath: /etc/wireguard
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tun
+          hostPath:
+            type: 'CharDevice'
+            path: /dev/net/tun
+        - name: config
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ include "wg-easy.fullname" . }}{{- end }}
+        {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/wg-easy/templates/ingress.yaml
+++ b/charts/wg-easy/templates/ingress.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/wg-easy/templates/ingress.yaml
+++ b/charts/wg-easy/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "wg-easy.fullname" . -}}
+{{- $svcPort := .Values.web.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      {{- if .secretName }}
+      secretName: {{ .secretName }}
+      {{- end -}}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-web
+                port:
+                  number: {{ $.Values.web.service.port }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/wg-easy/templates/pvc.yaml
+++ b/charts/wg-easy/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.persistence.enabled -}}
+{{- $fullName := include "wg-easy.fullname" . -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ $fullName }}"
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistence.accessModes | indent 4 }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- if .Values.persistence.volumeBindingMode }}
+  volumeBindingModeName: "{{ .Values.persistence.volumeBindingMode }}"
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistence.size }}"
+{{- end -}}

--- a/charts/wg-easy/templates/service.yaml
+++ b/charts/wg-easy/templates/service.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wg-easy.fullname" . }}-web
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  annotations:
+  {{- range $key, $value := .Values.web.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  type: {{ .Values.web.service.type }}
+{{- if .Values.web.service.clusterIP }}
+  clusterIP: {{ .Values.web.service.clusterIP }}
+{{- end }}
+{{- if .Values.web.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.web.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.web.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.web.service.externalTrafficPolicy }}
+{{- end }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: {{ .Values.web.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "wg-easy.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wg-easy.fullname" . }}-wg
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  annotations:
+  {{- range $key, $value := .Values.wireguard.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  type: {{ .Values.wireguard.service.type }}
+{{- if .Values.wireguard.service.clusterIP }}
+  clusterIP: {{ .Values.wireguard.service.clusterIP }}
+{{- end }}
+{{- if .Values.wireguard.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.wireguard.service.loadBalancerIP }}
+{{- end }}
+{{- if .Values.wireguard.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.wireguard.service.externalTrafficPolicy }}
+{{- end }}
+  ports:
+    - port: {{ .Values.wireguard.service.port }}
+      targetPort: {{ .Values.wireguard.service.port }}
+      protocol: UDP
+      name: wireguard
+  selector:
+    {{- include "wg-easy.selectorLabels" . | nindent 4 }}

--- a/charts/wg-easy/templates/serviceaccount.yaml
+++ b/charts/wg-easy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wg-easy.serviceAccountName" . }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -1,0 +1,85 @@
+# Default values for wg-easy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: weejewel/wg-easy
+  tag: 4
+  pullPolicy: IfNotPresent
+
+web:
+  # Set password.secretName if you want to set a web password
+  # password:
+  #   secretName: ""
+  service:
+    type: ClusterIP
+    port: 51821
+    externalTrafficPolicy: Local
+    annotations: {}
+
+wireguard:
+  service:
+    type: ClusterIP
+    port: 51820
+    externalTrafficPolicy: Local
+    annotations: {}
+
+  # Wireguard host is required and used when creating client config
+  host: ""
+  clientAddrRange: 10.8.0.x
+  dns: 1.1.1.1
+  allowedIps: "0.0.0.0/0, ::/0"
+  persistentKeepalive: 0
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: chart-example.local
+      paths: []
+      # - path: /
+      #   pathType: Prefix
+  # tls:
+  #   - hosts:
+  #      - chart-example.local
+
+persistence:
+  enabled: false
+  size: 100Mi
+  annotations: {}
+  # storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  subPath: ""
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This adds a Helm chart and GitHub workflow to publish the Helm chart to the `gh-pages` branch (default for the official [helm-chart-releaser](https://github.com/marketplace/actions/helm-chart-releaser) GitHub Action), which allows users to add the helm chart for easy installation to a Kubernetes cluster, something along the lines of:

```bash
helm repo add wg-easy https://weejewel.github.io/wg-easy
helm install wg-easy wg-easy/wg-easy
```
If this is not wanted to be added to this project, feel free to close this out. Thanks for the project!

Resolves #126 