### PR TITLE
remove node cache in the final docker image (~/.npm/_cacache/ folder) -> 11% smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ RUN apk add -U --no-cache wireguard-tools dumb-init
 # Copy Web UI
 COPY src/ /app/
 WORKDIR /app
-RUN npm ci --production
-RUN npm i -g nodemon
+RUN npm ci --production \
+&&  npm i -g nodemon \
+&&  npm cache clear --force
 RUN mv /app/node_modules/ /node_modules/
 
 # Expose Ports

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY src/ /app/
 WORKDIR /app
 RUN npm ci --production \
 &&  npm i -g nodemon \
-&&  npm cache clear --force
-RUN mv /app/node_modules/ /node_modules/
+&&  npm cache clear --force \
+&&  mv /app/node_modules/ /node_modules/
 
 # Expose Ports
 EXPOSE 51820/udp


### PR DESCRIPTION
Hello @WeeJeWel, I loved the project! Keep up the awesome work :)

Out of curiosity, I ran the dive tool (https://github.com/wagoodman/dive) I find some node cache files ~/.npm/_cacache/

I changed the Dockerfile to remove them making the final docker image smaller, previous it was 143MB now 132MB (uncompressed) an 8% improvement.

Signed-off-by: caioau <caio.volpato@riseup.net>