### PR TITLE
Button to toggle charts visibility

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -63,6 +63,19 @@
                 </svg>
                 <span class="text-sm">New</span>
               </button>
+
+              <button @click="toggleCharts();"
+                class="hover:bg-red-800 hover:border-red-800 hover:text-white text-gray-700 border-2 border-gray-100 py-2 px-4 rounded inline-flex items-center transition">
+                <svg class="w-4 mr-2" inline xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 455 455">
+                  <path d="M415,102.509c-22.091,0-40,17.909-40,40c0,5.542,1.128,10.821,3.166,15.62l-83.791,83.792
+                    c-4.799-2.038-10.078-3.167-15.621-3.167s-10.822,1.129-15.621,3.167l-50.053-50.053c2.038-4.799,3.166-10.078,3.166-15.621
+                    c0-22.091-17.909-40-40-40c-22.091,0-40,17.909-40,40c0,5.542,1.128,10.821,3.166,15.62l-83.792,83.791
+                    c-4.799-2.038-10.078-3.167-15.621-3.167c-22.091,0-40,17.909-40,40s17.909,40,40,40s40-17.909,40-40
+                    c0-5.542-1.128-10.821-3.166-15.62l83.792-83.791c4.799,2.038,10.078,3.166,15.621,3.166c5.542,0,10.821-1.128,15.62-3.166
+                    l50.054,50.054c-2.038,4.799-3.166,10.078-3.166,15.62c0,22.091,17.909,40,40,40c22.091,0,40-17.909,40-40
+                    c0-5.542-1.128-10.821-3.166-15.62l83.791-83.792c4.799,2.038,10.078,3.166,15.621,3.166c22.091,0,40-17.909,40-40
+                    S437.091,102.509,415,102.509z" />
+                <span class="text-sm">Charts</span>
             </div>
           </div>
 
@@ -72,11 +85,11 @@
               class="relative overflow-hidden border-b border-gray-100 border-solid">
 
               <!-- Chart -->
-              <div class="absolute z-0 bottom-0 left-0 right-0" style="top: 60%;">
+              <div v-if="chartsVisible" class="absolute z-0 bottom-0 left-0 right-0" style="top: 60%;">
                 <apexchart width="100%" height="100%" :options="client.chartOptions" :series="client.transferTxSeries">
                 </apexchart>
               </div>
-              <div class="absolute z-0 top-0 left-0 right-0" style="bottom: 60%;">
+              <div v-if="chartsVisible" class="absolute z-0 top-0 left-0 right-0" style="bottom: 60%;">
                 <apexchart width="100%" height="100%" :options="client.chartOptions" :series="client.transferRxSeries"
                   style="transform: scaleY(-1);">
                 </apexchart>
@@ -481,5 +494,3 @@
   <script src="./js/api.js"></script>
   <script src="./js/app.js"></script>
 </body>
-
-</html>

--- a/src/www/js/app.js
+++ b/src/www/js/app.js
@@ -48,6 +48,7 @@ new Vue({
     currentRelease: null,
     latestRelease: null,
 
+    chartsVisible: (localStorage.getItem('chartsVisible') ?? 'true') === 'true',
     chartOptions: {
       chart: {
         background: 'transparent',
@@ -242,6 +243,10 @@ new Vue({
       this.api.updateClientAddress({ clientId: client.id, address })
         .catch(err => alert(err.message || err.toString()))
         .finally(() => this.refresh().catch(console.error));
+    },
+    toggleCharts() {
+      this.chartsVisible = !this.chartsVisible;
+      localStorage.setItem('chartsVisible', this.chartsVisible);
     },
   },
   filters: {


### PR DESCRIPTION
Greetings!

First off, thanks for making this project. It has greatly simplified my WireGuard deployments!

However, in one my deployments, I currently have 12 devices enrolled (and increasing). This has presented a performance issue with the live Rx/Tx graphs. On my M1 Macbook Pro (and other devices as well), using Brave or Firefox, in times where there is a lot of network activity, the **UI frequently stays unresponsive**. Low network (and therefore chart) activity seems to improve things but it's still far from ideal.

I believe the same issue is described here as well: https://github.com/WeeJeWel/wg-easy/issues/187

My solution is to add a "Charts" button at the top right which simply toggles the visibility of live charts. 
![charts](https://user-images.githubusercontent.com/9743170/162045725-2ff00295-e260-4d50-9e81-d1cb9152d0a3.png)

Testing on my Macbook, hiding the charts seems to _drastically_ improve UI responsiveness. A better solution would probably be to look into the charting library or switch to a different one, but unfortunately I don't have the time to dig into this at the moment.

Visibility state is also stored in localStorage for convenience.

Icon source: https://www.svgrepo.com/svg/17087/graph

Let me know what you think,
~ MK