### PR TITLE
Update WireGuard.js ( WG_PORT variable fix ) 

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -93,7 +93,7 @@ module.exports = class WireGuard {
 [Interface]
 PrivateKey = ${config.server.privateKey}
 Address = ${config.server.address}/24
-ListenPort = 51820
+ListenPort = ${WG_PORT}
 PostUp = ${WG_POST_UP}
 PostDown = ${WG_POST_DOWN}
 `;


### PR DESCRIPTION
Fix for WG_PORT variable, because it was hardcoded to 51820 before.