### PR TITLE
Add non-docker documentation and systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ $ docker run -d \
   weejewel/wg-easy
 </pre>
 
-If you don't want to use docker, then add the sysctl tweaks listed above, and install wireguard, nodejs and npm from your package manager. After that, run the following
+If you don't want to use docker, then install wireguard, nodejs and npm from your package manager and then, run the following
 <pre>
+echo net.ipv4.ip_forward=1 >> /etc/sysctl.conf
+echo net.ipv4.conf.all.src_valid_mark=1 >> /etc/sysctl.conf
+sysctl -p
 git clone https://github.com/WeeJeWel/wg-easy
 cd wg-easy
 mv src /app

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You have found the easiest way to install & manage WireGuard on any Linux host!
 ## Requirements
 
 * A host with a kernel that supports WireGuard (all modern kernels).
-* A host with Docker installed.
+* A host with Docker installed (or you could use the non-docker installation instructions).
 
 ## Installation
 
@@ -99,6 +99,10 @@ Are you enjoying this project? [Buy me a beer!](https://github.com/sponsors/WeeJ
 
 These options can be configured by setting environment variables using `-e KEY="VALUE"` in the `docker run` command.
 
+If you are using the systemd service, then you can add new ones using `Environment=KEY=VALUE` under the [Service] Section in the service file.
+
+
+
 | Env | Default | Example | Description |
 | - | - | - | - |
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
@@ -125,3 +129,15 @@ docker pull weejewel/wg-easy
 ```
 
 And then run the `docker run -d \ ...` command above again.
+
+If you are using the non-docker installation, then do the following
+<pre>
+git clone https://github.com/WeeJeWel/wg-easy # do this if you dont have the repository cloned aldready
+cd wg-easy
+git pull
+rm -rf /app /node_modules
+mv src /app
+cd /app
+npm ci --production
+cp node_modules ..
+</pre>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ $ docker run -d \
   weejewel/wg-easy
 </pre>
 
+If you don't want to use docker, then add the sysctl tweaks listed above, and install wireguard, nodejs and npm from your package manager. After that, run the following
+<pre>
+git clone https://github.com/WeeJeWel/wg-easy
+cd wg-easy
+mv src /app
+cd /app
+npm ci --production
+cp node_modules ..
+ufw allow 51821/tcp # (webui) Only for users of the UFW firewall
+ufw allow 51820/udp # (wireguard listening port) Only for users of the UFW firewall
+cd -
+cp wg-easy.service /etc/systemd/system
+nano /etc/systemd/system/wg-easy.service # Replace everything that is marked as 'REPLACEME' and tweak it to your liking
+systemctl daemon-reload
+systemctl enable --now wg-easy.service
+systemctl start wg-easy.service
+</pre>
+
 > 💡 Replace `YOUR_SERVER_IP` with your WAN IP, or a Dynamic DNS hostname.
 > 
 > 💡 Replace `YOUR_ADMIN_PASSWORD` with a password to log in on the Web UI.

--- a/wg-easy.service
+++ b/wg-easy.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=The easiest way to run WireGuard VPN with Web-based Admin UI
+[Service]
+Environment=DEBUG=Server,Wireguard
+# Your server IP/domain
+Environment=WG_HOST=REPLACEME 
+# IP Range for Devices to use
+Environment=WG_DEFAULT_ADDRESS=10.7.0.x
+# Default DNS 
+Environment=WG_DEFAULT_DNS=9.9.9.9 
+# Admin Panel Password (Please use a strong and complicated one)
+Environment=PASSWORD=REPLACEME
+WorkingDirectory=/app
+ExecStart=node server.js
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
For my use case, using docker was not feasable since services on the vps hosting wg-easy is accessing services hosted in a device connected to the wireguard.
So i made this service file and it has been working well for me.

This might help others who cant use docker like me.

Regards,
Arya

