### PR TITLE
Added option for Interface choice for the webserver to listen on

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on `51820` inside the Docker container. |
-| `INTERFACE` | `eth0` | `wlan0` | The interface to set the HTTP listener on for the WebGUI |
+| `WG_WEB_INTERFACE` | `eth0` | `wlan0` | The interface to set the HTTP listener on for the WebGUI |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |
 | `WG_DEFAULT_ADDRESS` | `10.8.0.x` | `10.6.0.x` | Clients IP address range. |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
 | `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on `51820` inside the Docker container. |
+| `INTERFACE` | `eth0` | `wlan0` | The interface to set the HTTP listener on for the WebGUI |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |
 | `WG_DEFAULT_ADDRESS` | `10.8.0.x` | `10.6.0.x` | Clients IP address range. |

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const { release } = require('./package.json');
 
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
+module.exports.INTERFACE = process.env.INTERFACE || eth0;
 module.exports.PASSWORD = process.env.PASSWORD;
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_HOST = process.env.WG_HOST;
@@ -18,7 +19,7 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o eth0 -j MASQUERADE;
+iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.INTERFACE} -j MASQUERADE;
 iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
 iptables -A FORWARD -i wg0 -j ACCEPT;
 iptables -A FORWARD -o wg0 -j ACCEPT;

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ const { release } = require('./package.json');
 
 module.exports.RELEASE = release;
 module.exports.PORT = process.env.PORT || 51821;
-module.exports.INTERFACE = process.env.INTERFACE || eth0;
+module.exports.WG_WEB_INTERFACE = process.env.WG_WEB_INTERFACE || eth0;
 module.exports.PASSWORD = process.env.PASSWORD;
 module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_HOST = process.env.WG_HOST;
@@ -19,7 +19,7 @@ module.exports.WG_ALLOWED_IPS = process.env.WG_ALLOWED_IPS || '0.0.0.0/0, ::/0';
 
 module.exports.WG_PRE_UP = process.env.WG_PRE_UP || '';
 module.exports.WG_POST_UP = process.env.WG_POST_UP || `
-iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.INTERFACE} -j MASQUERADE;
+iptables -t nat -A POSTROUTING -s ${module.exports.WG_DEFAULT_ADDRESS.replace('x', '0')}/24 -o ${module.exports.WG_WEB_INTERFACE} -j MASQUERADE;
 iptables -A INPUT -p udp -m udp --dport 51820 -j ACCEPT;
 iptables -A FORWARD -i wg0 -j ACCEPT;
 iptables -A FORWARD -o wg0 -j ACCEPT;


### PR DESCRIPTION
Added the option to let the user specify an interface for the webserver to run on since by default it will only run on eth0, this lets you set add -e INTERFACE=wlan0 for example to the docker run script and makes it work with any interfaces. It was mentioned in this issue https://github.com/WeeJeWel/wg-easy/issues/309