### PR TITLE
Add `tcpdump` package in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN npm i -g nodemon
 
 # Install Linux packages
 RUN apk add -U --no-cache \
+  tcpdump \
   wireguard-tools \
   dumb-init
 


### PR DESCRIPTION
Having `tcpdump` available in our wireguard container makes it easier to debug configuration issues and/or monitor network traffic