### PR TITLE
Patch to make custom DNS work via WG_DEFAULT_DNS

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -100,6 +100,7 @@ PreUp = ${WG_PRE_UP}
 PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}
 PostDown = ${WG_POST_DOWN}
+${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}` : ''}
 `;
 
     for (const [clientId, client] of Object.entries(config.clients)) {

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -95,12 +95,12 @@ module.exports = class WireGuard {
 [Interface]
 PrivateKey = ${config.server.privateKey}
 Address = ${config.server.address}/24
+${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}` : ''}
 ListenPort = 51820
 PreUp = ${WG_PRE_UP}
 PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}
 PostDown = ${WG_POST_DOWN}
-${WG_DEFAULT_DNS ? `DNS = ${WG_DEFAULT_DNS}` : ''}
 `;
 
     for (const [clientId, client] of Object.entries(config.clients)) {


### PR DESCRIPTION
Currently `WG_DEFAULT_DNS` is only added to the peer config, but is required in the main config for DNS. Without this change defining the `WG_DEFAULT_DNS` environment variable will cause the peer's DNS lookups to fail to resolve.