### PR TITLE
Allow use WG_HOST=auto to resolve host programatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN npm i -g nodemon
 
 # Install Linux packages
 RUN apk add -U --no-cache \
+  curl \
   wireguard-tools \
   dumb-init
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These options can be configured by setting environment variables using `-e KEY="
 | Env | Default | Example | Description |
 | - | - | - | - |
 | `PASSWORD` | - | `foobar123` | When set, requires a password when logging in to the Web UI. |
-| `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. |
+| `WG_HOST` | - | `vpn.myserver.com` | The public hostname of your VPN server. Set `auto`, to resolve it via `icanhazip.com` service |
 | `WG_PORT` | `51820` | `12345` | The public UDP port of your VPN server. WireGuard will always listen on `51820` inside the Docker container. |
 | `WG_MTU` | `null` | `1420` | The MTU the clients will use. Server uses default WG MTU. |
 | `WG_PERSISTENT_KEEPALIVE` | `0` | `25` | Value in seconds to keep the "connection" open. If this value is 0, then connections won't be kept alive. |

--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -30,8 +30,13 @@ module.exports = class WireGuard {
   async getConfig() {
     if (!this.__configPromise) {
       this.__configPromise = Promise.resolve().then(async () => {
+        let wgHost;
         if (!WG_HOST) {
           throw new Error('WG_HOST Environment Variable Not Set!');
+        } else if (WG_HOST === 'auto') {
+          wgHost = await Util.exec('curl -s icanhazip.com');
+        } else {
+          wgHost = WG_HOST;
         }
 
         debug('Loading configuration...');
@@ -52,6 +57,7 @@ module.exports = class WireGuard {
               privateKey,
               publicKey,
               address,
+              wgHost,
             },
             clients: {},
           };
@@ -208,7 +214,7 @@ PublicKey = ${config.server.publicKey}
 PresharedKey = ${client.preSharedKey}
 AllowedIPs = ${WG_ALLOWED_IPS}
 PersistentKeepalive = ${WG_PERSISTENT_KEEPALIVE}
-Endpoint = ${WG_HOST}:${WG_PORT}`;
+Endpoint = ${config.server.wgHost || WG_HOST}:${WG_PORT}`;
   }
 
   async getClientQRCodeSVG({ clientId }) {


### PR DESCRIPTION
This PR allows to use auto value of WG_HOST like in other docker wireguard implementation ([linuxserver/docker-wireguard](https://github.com/linuxserver/docker-wireguard/blob/ac5f805be80e558ccec1492e90295d1a179739b4/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run#L145)) to resolve IP of server for configs
