### PR TITLE
Respect user-selected WG_PORT

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -95,7 +95,7 @@ module.exports = class WireGuard {
 [Interface]
 PrivateKey = ${config.server.privateKey}
 Address = ${config.server.address}/24
-ListenPort = 51820
+ListenPort = ${WG_PORT}
 PreUp = ${WG_PRE_UP}
 PostUp = ${WG_POST_UP}
 PreDown = ${WG_PRE_DOWN}


### PR DESCRIPTION
I found that setting the WG_PORT env var did not successfully change the listen port of the service. This fills that in in the wg0.conf template.